### PR TITLE
feat(kafka): add kafka generic controller 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+Rev: 1.1.0
+=============
+ ## Added
+- New kafka generic controller for nest microservices applications
+- Avro deserializer
+- Generic interface for debezium data
+- New logic in extraArgs: possibility to add a fixed filter with runtime value assignment.
+
+## Changed
+- join field type is only JoinType
+
+## Fixed
+- DateType  graphql scalar
+- Fixed filterConditions problem with some filter on Date type
+- Fixed One-to-many relationship problem with nested resource as aggrid type
+
+
+
+
+

--- a/ag-grid/src/__mocks__/filter.mocks.ts
+++ b/ag-grid/src/__mocks__/filter.mocks.ts
@@ -200,6 +200,12 @@ export const fixedArgsOptions: IAgGridArgsOptions = {
   },
   extraArgs: {
     ...genExtraArgs('default'),
+    testExtra: {
+      hidden: true,
+      filterMiddleware: () => 'test',
+      filterType: FilterType.TEXT,
+      filterCondition: GeneralFilters.EQUAL,
+    },
   },
   extraArgsStrategy: null,
   defaultValue: {},

--- a/ag-grid/src/__tests__/ag-grid-args.decorator.spec.ts
+++ b/ag-grid/src/__tests__/ag-grid-args.decorator.spec.ts
@@ -402,6 +402,27 @@ describe('Ag-grid args decorator', () => {
       expect(resultFn(params)()).toBeDefined();
     });
 
+    it('Should work properly with extraArgs property with middleware ', () => {
+      const params: IAgGridArgsOptions = {
+        ...fixedArgsOptions,
+        extraArgsStrategy: ExtraArgsStrategy.AT_LEAST_ONE,
+        extraArgs: {
+          ...genExtraArgs('groupKeys'),
+        },
+      };
+
+      expect(resultFn(params)()).toBeDefined();
+      params.extraArgsStrategy = ExtraArgsStrategy.ONLY_ONE;
+      params.extraArgs = {
+        ...genExtraArgs('rowGroups'),
+      };
+
+      expect(resultFn(params)()).toBeDefined();
+
+      params.extraArgsStrategy = ExtraArgsStrategy.DEFAULT;
+      expect(resultFn(params)()).toBeDefined();
+    });
+
     it('Should add extraArgs with VIRTUAL filter in extra field of findManyOptions', () => {
       const params: IAgGridArgsOptions = {
         ...fixedArgsOptions,

--- a/ag-grid/src/ag-grid-args.decorator.ts
+++ b/ag-grid/src/ag-grid-args.decorator.ts
@@ -481,9 +481,17 @@ export function mapAgGridParams(
         extraParameter[argName] = args[argName];
         continue;
       }
+
+      let value = args[argName];
+      const filterMiddleware = params.extraArgs[argName].filterMiddleware;
+
+      if (filterMiddleware) {
+        value = filterMiddleware(value);
+      }
+
       forcedFilters.push({
         key: argName, // the column name mapping is executed internally
-        value: args[argName],
+        value,
         descriptors: params.extraArgs[argName],
       });
     }
@@ -542,6 +550,8 @@ export const AgGridCombineDecorators = (params: IAgGridArgsOptions) => {
   const argDecorators: ParameterDecorator[] = [];
   if (params.extraArgs) {
     for (const argName of Object.keys(params.extraArgs)) {
+      if (params.extraArgs[argName].hidden) continue;
+
       argDecorators.push(
         Args(argName, params.extraArgs[argName].options ?? {}),
       );

--- a/ag-grid/src/ag-grid.input.ts
+++ b/ag-grid/src/ag-grid.input.ts
@@ -119,6 +119,7 @@ export function filterExpressionInputFactory<Entity>(
     )
     field: string;
     filter: number;
+    filterTo?: number;
   }
 
   @InputType(`${entityModel.name}FilterDateInput`)
@@ -131,7 +132,8 @@ export function filterExpressionInputFactory<Entity>(
       () => FieldEnum,
     )
     field: string;
-    filter: number;
+    dateFrom: string;
+    dateTo?: string;
   }
 
   @InputType(`${entityModel.name}FilterSetInput`)
@@ -236,7 +238,7 @@ export function agJoinArgFactory<Entity>(
   }
 
   registerEnumType(JoinTypes, {
-    name: `${entityModel.name}JoinTypes`,
+    name: `JoinTypes`,
   });
 
   @InputType(`${entityModel.name}JoinOptionsInputType`)

--- a/ag-grid/src/ag-grid.interface.ts
+++ b/ag-grid/src/ag-grid.interface.ts
@@ -210,6 +210,14 @@ export interface IExtraArg {
   options?: ArgsOptions;
   filterType: FilterType;
   filterCondition: GeneralFilters;
+  /**
+   *
+   */
+  filterMiddleware?: { (filterValue?: any): any };
+  /**
+   *
+   */
+  hidden?: boolean;
 }
 
 export interface IAgGridArgsSingleOptions {

--- a/ag-grid/src/generic-resolver.resolver.ts
+++ b/ag-grid/src/generic-resolver.resolver.ts
@@ -175,7 +175,7 @@ export function defineFieldResolver<Entity extends Record<string, any> = any>(
     if (Array.isArray(relType)) {
       relType = relType[0];
     } else if (!relType) {
-      throw new AgGridError('relation type indefined');
+      throw new AgGridError('relation type undefined');
     }
 
     if (

--- a/ag-grid/src/generic-service.service.ts
+++ b/ag-grid/src/generic-service.service.ts
@@ -120,7 +120,7 @@ export class GenericService<EntityRead, EntityWrite = EntityRead> {
    * Switches this Service database connection to a new specified database
    * @param dbName The database name
    */
-  protected switchDatabaseConnection(dbName: string): void {
+  public switchDatabaseConnection(dbName: string): void {
     const connectionName = getConnectionName(dbName);
     const connection = getConnection(connectionName);
     this.setRepositoryRead(

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -19,7 +19,7 @@ Object.keys(tsProjects.compilerOptions.paths).map((k: string) => {
 });
 
 const options: IOptions = {
-  skipProjects: ['types', 'graphql'],
+  skipProjects: ['types', 'graphql', 'kafka'],
 };
 
 export default jestConfGenerator(

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -19,7 +19,7 @@ Object.keys(tsProjects.compilerOptions.paths).map((k: string) => {
 });
 
 const options: IOptions = {
-  skipProjects: ['types', 'graphql', 'kafka'],
+  skipProjects: ['types', 'graphql'],
 };
 
 export default jestConfGenerator(

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,9 +2,9 @@ import {
   IAppProjSetting,
   IOptions,
   jestConfGenerator,
-} from "./jest/src/config/jest-conf.generator";
+} from './jest/src/config/jest-conf.generator';
 
-const tsProjects = require("./tsconfig.json");
+const tsProjects = require('./tsconfig.json');
 
 const appProjectsSettings: { [key: string]: IAppProjSetting } = {};
 
@@ -13,18 +13,18 @@ let projectList: { [key: string]: string } = {};
 Object.keys(tsProjects.compilerOptions.paths).map((k: string) => {
   const path: string = tsProjects.compilerOptions.paths[k][0];
 
-  if (!k.endsWith("*")) {
-    projectList[k] = path.replace("/src", "");
+  if (!k.endsWith('*')) {
+    projectList[k] = path.replace('/src', '');
   }
 });
 
 const options: IOptions = {
-  skipProjects: ["types", "graphql"],
+  skipProjects: ['types', 'graphql'],
 };
 
 export default jestConfGenerator(
   __dirname,
   projectList,
   appProjectsSettings,
-  options
+  options,
 );

--- a/kafka/package.json
+++ b/kafka/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@nestjs-yalc/kafka",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.ts",
+  "exports": {
+    "./": "./src/"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "AGPL-3.0-or-later"
+}

--- a/kafka/src/__test__/avro-deserializer.spec.ts
+++ b/kafka/src/__test__/avro-deserializer.spec.ts
@@ -1,0 +1,42 @@
+import { createMock } from '@golevelup/ts-jest';
+import * as confluent from '@kafkajs/confluent-schema-registry';
+import { KafkaAvroDeserializer } from '../plugin';
+
+jest.mock('@kafkajs/confluent-schema-registry', () => {
+  const mockedSchema = createMock<confluent.SchemaRegistry>();
+  mockedSchema.decode.mockResolvedValue('decoded');
+
+  return {
+    SchemaRegistry: jest.fn(() => mockedSchema),
+  };
+});
+
+describe('KafkaAvroDeserializer', () => {
+  let deserializer = new KafkaAvroDeserializer({}, {});
+
+  it('Should be defined', () => {
+    expect(deserializer).toBeDefined();
+  });
+
+  it('Should decode message', async () => {
+    const result = await deserializer.deserialize({
+      key: 'key',
+      value: 'value',
+      pattern: 'pettern',
+    });
+
+    expect(result.data.key).toEqual('decoded');
+    expect(result.data.value).toEqual('decoded');
+  });
+
+  it('Should not decode message', async () => {
+    const result = await deserializer.deserialize({
+      key: undefined,
+      value: undefined,
+      pattern: 'pettern',
+    });
+
+    expect(result.data.key).toBeUndefined();
+    expect(result.data.value).toBeUndefined();
+  });
+});

--- a/kafka/src/__test__/kafka.controller.spec.ts
+++ b/kafka/src/__test__/kafka.controller.spec.ts
@@ -1,0 +1,32 @@
+import { BaseEntity, Repository } from 'typeorm';
+import { KafkaController } from '../kafka.controller';
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+
+class TestEntity {
+  testProperty: string;
+}
+
+describe('Kafka Controller', () => {
+  let repository: DeepMocked<Repository<BaseEntity>>;
+  let controller: KafkaController<BaseEntity>;
+  beforeAll(() => {
+    repository = createMock<Repository<BaseEntity>>();
+    controller = new KafkaController(repository);
+  });
+  it('Should be defined', async () => {
+    expect(controller).toBeDefined();
+
+    await expect(controller.deleteEntity({})).resolves.toBeDefined();
+    await expect(controller.saveEntity({})).resolves.toBeDefined();
+    await expect(controller.saveEntityOrUpdate({}, [])).resolves.toBeDefined();
+  });
+
+  it('Should filter the target value', () => {
+    const test = new TestEntity();
+    test.testProperty = 'testProperty';
+    const result = controller.checkTargetValue(test, 'testProperty', [
+      'testProperty',
+    ]);
+    expect(result).toBeTruthy();
+  });
+});

--- a/kafka/src/index.ts
+++ b/kafka/src/index.ts
@@ -1,0 +1,4 @@
+/* istanbul ignore file */
+export * from './plugin';
+export * from './kafka.controller';
+export * from './interface';

--- a/kafka/src/interface/config.interface.ts
+++ b/kafka/src/interface/config.interface.ts
@@ -1,0 +1,5 @@
+export interface IKafkaConfig {
+  clientBroker: string;
+  schemaRegistry: string;
+  constumerGroupId: string;
+}

--- a/kafka/src/interface/config.interface.ts
+++ b/kafka/src/interface/config.interface.ts
@@ -1,5 +1,21 @@
 export interface IKafkaConfig {
-  clientBroker: string;
-  schemaRegistry: string;
-  constumerGroupId: string;
+  kafka: {
+    host: string;
+    sslEnabled: boolean;
+    authEnabled: boolean;
+    cliendId?: string;
+    credentials?: {
+      username: string;
+      password: string;
+    };
+    constumerGroupId: string;
+  };
+  schemaRegistry: {
+    url: string;
+    authEnabled: boolean;
+    credentials?: {
+      username: string;
+      password: string;
+    };
+  };
 }

--- a/kafka/src/interface/debezium.interface.ts
+++ b/kafka/src/interface/debezium.interface.ts
@@ -1,0 +1,12 @@
+export type DebeziumOperation = 'c' | 'r' | 'u' | 'd';
+
+export type DebeziumEvenelope<T> = {
+  before: null | T;
+  after: null | T;
+  op: DebeziumOperation;
+};
+
+export type DeserializedData<TKey, TValue> = {
+  key: TKey;
+  value: DebeziumEvenelope<TValue>;
+};

--- a/kafka/src/interface/index.ts
+++ b/kafka/src/interface/index.ts
@@ -1,2 +1,4 @@
+/* istanbul ignore file */
+
 export * from './debezium.interface';
 export * from './config.interface';

--- a/kafka/src/interface/index.ts
+++ b/kafka/src/interface/index.ts
@@ -1,0 +1,2 @@
+export * from './debezium.interface';
+export * from './config.interface';

--- a/kafka/src/kafka.controller.ts
+++ b/kafka/src/kafka.controller.ts
@@ -1,0 +1,55 @@
+import { Controller } from '@nestjs/common';
+import { DeepPartial, FindConditions, Repository } from 'typeorm';
+
+@Controller()
+export class KafkaController<Entity> {
+  constructor(protected repository: Repository<Entity>) {}
+
+  protected setRepository(repository: Repository<Entity>): void {
+    this.repository = repository;
+  }
+
+  /**
+   * Check function for filtering target with specific value on a key
+   * @param target Entity
+   * @param key Key of the Entity fields
+   * @param value Value to filter
+   * @returns true if match - false otherwise
+   */
+  checkTargetValue<Entity, U extends keyof Entity>(
+    target: Entity,
+    key: U,
+    value: Array<Entity[U]>,
+  ): boolean {
+    return value.includes(target[key]);
+  }
+
+  /**
+   * Save entity on Database
+   * @param entity
+   * @returns
+   */
+  saveEntity(entity: DeepPartial<Entity>) {
+    return this.repository.insert(entity);
+  }
+
+  saveEntityOrUpdate(
+    entity: DeepPartial<Entity>,
+    overWrite: string[],
+    conflitTarget?: string | string[],
+  ) {
+    return this.repository
+      .createQueryBuilder()
+      .insert()
+      .values(entity)
+      .orUpdate(overWrite, conflitTarget)
+      .execute();
+  }
+
+  deleteEntity(conditions: FindConditions<Entity>) {
+    return this.repository.delete(conditions);
+    /**
+     * Place repository for deleting the entity
+     */
+  }
+}

--- a/kafka/src/kafka.controller.ts
+++ b/kafka/src/kafka.controller.ts
@@ -5,10 +5,6 @@ import { DeepPartial, FindConditions, Repository } from 'typeorm';
 export class KafkaController<Entity> {
   constructor(protected repository: Repository<Entity>) {}
 
-  protected setRepository(repository: Repository<Entity>): void {
-    this.repository = repository;
-  }
-
   /**
    * Check function for filtering target with specific value on a key
    * @param target Entity
@@ -29,7 +25,7 @@ export class KafkaController<Entity> {
    * @param entity
    * @returns
    */
-  saveEntity(entity: DeepPartial<Entity>) {
+  async saveEntity(entity: DeepPartial<Entity>) {
     return this.repository.insert(entity);
   }
 
@@ -40,7 +36,7 @@ export class KafkaController<Entity> {
    * @param conflitTarget
    * @returns
    */
-  saveEntityOrUpdate(
+  async saveEntityOrUpdate(
     entity: DeepPartial<Entity>,
     overWrite: string[],
     conflitTarget?: string | string[],
@@ -58,10 +54,7 @@ export class KafkaController<Entity> {
    * @param conditions
    * @returns
    */
-  deleteEntity(conditions: FindConditions<Entity>) {
+  async deleteEntity(conditions: FindConditions<Entity>) {
     return this.repository.delete(conditions);
-    /**
-     * Place repository for deleting the entity
-     */
   }
 }

--- a/kafka/src/kafka.controller.ts
+++ b/kafka/src/kafka.controller.ts
@@ -33,6 +33,13 @@ export class KafkaController<Entity> {
     return this.repository.insert(entity);
   }
 
+  /**
+   * Save the entity or Update in case of confitColumn
+   * @param entity
+   * @param overWrite
+   * @param conflitTarget
+   * @returns
+   */
   saveEntityOrUpdate(
     entity: DeepPartial<Entity>,
     overWrite: string[],
@@ -46,6 +53,11 @@ export class KafkaController<Entity> {
       .execute();
   }
 
+  /**
+   * Delete the entity
+   * @param conditions
+   * @returns
+   */
   deleteEntity(conditions: FindConditions<Entity>) {
     return this.repository.delete(conditions);
     /**

--- a/kafka/src/plugin/avro-deserializer.ts
+++ b/kafka/src/plugin/avro-deserializer.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import { Deserializer, ReadPacket } from '@nestjs/microservices';
 import { SchemaRegistry } from '@kafkajs/confluent-schema-registry';
 import { SchemaRegistryAPIClientArgs } from '@kafkajs/confluent-schema-registry/dist/api';
@@ -26,16 +27,16 @@ export class KafkaAvroDeserializer
    * @param _options
    * @returns
    */
-  async deserialize(message: any) {
+  async deserialize(message: any): Promise<ReadPacket> {
     try {
-      message.key =
-        message.key?.length > 0
-          ? await this.registry.decode(message.key)
-          : null;
+      message.key = message.key
+        ? await this.registry.decode(message.key)
+        : message.key;
       message.value = message.value
         ? await this.registry.decode(message.value)
         : message.value;
     } catch (e) {
+      /* istanbul ignore next */
       console.error('Deserialization error', e);
     }
 

--- a/kafka/src/plugin/avro-deserializer.ts
+++ b/kafka/src/plugin/avro-deserializer.ts
@@ -26,7 +26,7 @@ export class KafkaAvroDeserializer
    * @param _options
    * @returns
    */
-  async deserialize(message: any, _options?: Record<string, any>) {
+  async deserialize(message: any) {
     try {
       message.key =
         message.key?.length > 0

--- a/kafka/src/plugin/avro-deserializer.ts
+++ b/kafka/src/plugin/avro-deserializer.ts
@@ -1,0 +1,50 @@
+import { Deserializer, ReadPacket } from '@nestjs/microservices';
+import { SchemaRegistry } from '@kafkajs/confluent-schema-registry';
+import { SchemaRegistryAPIClientArgs } from '@kafkajs/confluent-schema-registry/dist/api';
+import { SchemaRegistryAPIClientOptions } from '@kafkajs/confluent-schema-registry/dist/@types';
+import { KafkaMessage } from '@nestjs/microservices/external/kafka.interface';
+import { DeserializedData } from '../interface/debezium.interface';
+
+/**
+ * Deserializer for Kafka data by using Avro Schema
+ */
+export class KafkaAvroDeserializer
+  implements Deserializer<KafkaMessage, ReadPacket<DeserializedData<any, any>>>
+{
+  protected registry: SchemaRegistry;
+
+  constructor(
+    config: SchemaRegistryAPIClientArgs,
+    options?: SchemaRegistryAPIClientOptions,
+  ) {
+    this.registry = new SchemaRegistry(config, options);
+  }
+
+  /**
+   * Deserializer function: The return type must be a ReadPacket type for the purpose of using MessagePattern Nestjs
+   * @param message
+   * @param _options
+   * @returns
+   */
+  async deserialize(message: any, _options?: Record<string, any>) {
+    try {
+      message.key =
+        message.key?.length > 0
+          ? await this.registry.decode(message.key)
+          : null;
+      message.value = message.value
+        ? await this.registry.decode(message.value)
+        : message.value;
+    } catch (e) {
+      console.error('Deserialization error', e);
+    }
+
+    return {
+      pattern: message.topic,
+      data: {
+        value: message.value,
+        key: message.key,
+      },
+    };
+  }
+}

--- a/kafka/src/plugin/avro-deserializer.ts
+++ b/kafka/src/plugin/avro-deserializer.ts
@@ -37,6 +37,7 @@ export class KafkaAvroDeserializer
         : message.value;
     } catch (e) {
       /* istanbul ignore next */
+      // eslint-disable-next-line no-console
       console.error('Deserialization error', e);
     }
 

--- a/kafka/src/plugin/index.ts
+++ b/kafka/src/plugin/index.ts
@@ -1,0 +1,2 @@
+import { KafkaAvroDeserializer } from './avro-deserializer';
+export { KafkaAvroDeserializer };

--- a/kafka/src/plugin/index.ts
+++ b/kafka/src/plugin/index.ts
@@ -1,2 +1,3 @@
+/* istanbul ignore file */
 import { KafkaAvroDeserializer } from './avro-deserializer';
 export { KafkaAvroDeserializer };

--- a/kafka/tsconfig.dev.json
+++ b/kafka/tsconfig.dev.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.dev.json",
+  "include": ["src/**/*.ts"]
+}

--- a/kafka/tsconfig.lib.json
+++ b/kafka/tsconfig.lib.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.json"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nestjs-yalc/framework",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nestjs-yalc/framework",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "ag-grid",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@apollo/federation": "^0.33.3",
         "@apollo/subgraph": "^0.1.2",
         "@graphql-tools/wrap": "^8.3.0",
+        "@kafkajs/confluent-schema-registry": "^3.2.1",
         "@nestjs/axios": "^0.0.3",
         "@nestjs/common": "^8.1.1",
         "@nestjs/config": "^1.0.2",
@@ -46,7 +47,7 @@
         "commander": "^7.2.0",
         "csurf": "^1.11.0",
         "dataloader": "^2.0.0",
-        "decimal.js": "^3.0.1",
+        "decimal.js": "^10.3.1",
         "faker": "^5.5.2",
         "fastify-cookie": "^5.3.1",
         "google-libphonenumber": "^3.2.21",
@@ -78,7 +79,7 @@
         "jest": "^26.6.3",
         "jest-cli": "^26.6.3",
         "jest-config": "^27.3.1",
-        "prettier": "2.1.2",
+        "prettier": "^2.1.2",
         "ts-jest": "^26.5.6",
         "ts-node": "^9.1.1",
         "typescript": "4.3.5"
@@ -2383,6 +2384,37 @@
       "resolved": "https://registry.npmjs.org/@josephg/resolvable/-/resolvable-1.0.1.tgz",
       "integrity": "sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg=="
     },
+    "node_modules/@kafkajs/confluent-schema-registry": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@kafkajs/confluent-schema-registry/-/confluent-schema-registry-3.2.1.tgz",
+      "integrity": "sha512-UERxB+w7Av39IpUjj0aCogbSrCGIMTFdZGtyoOskB/rF3tOi7k45VqZwRHsmedAVqhvSGAw+tJKevjLrCIgnkw==",
+      "dependencies": {
+        "ajv": "^7.1.0",
+        "avsc": ">= 5.4.13 < 6",
+        "mappersmith": ">= 2.30.1 < 3",
+        "protobufjs": "^6.10.1"
+      }
+    },
+    "node_modules/@kafkajs/confluent-schema-registry/node_modules/ajv": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
+      "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@kafkajs/confluent-schema-registry/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/@nestjs-yalc/ag-grid": {
       "resolved": "ag-grid",
       "link": true
@@ -3904,6 +3936,14 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/avsc": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.3.tgz",
+      "integrity": "sha512-uUbetCWczQHbsKyX1C99XpQHBM8SWfovvaZhPIj23/1uV7SQf0WeRZbiLpw0JZm+LHTChfNgrLfDJOVoU2kU+A==",
+      "engines": {
+        "node": ">=0.11"
+      }
+    },
     "node_modules/avvio": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/avvio/-/avvio-7.2.2.tgz",
@@ -5212,12 +5252,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-3.0.1.tgz",
-      "integrity": "sha1-Rgmlo0P4t69Cn6dupKTEQnxtBl4=",
-      "engines": {
-        "node": "*"
-      }
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
@@ -11259,12 +11296,6 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/decimal.js": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
-      "dev": true
-    },
     "node_modules/jsdom/node_modules/ws": {
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
@@ -11769,6 +11800,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/mappersmith": {
+      "version": "2.38.1",
+      "resolved": "https://registry.npmjs.org/mappersmith/-/mappersmith-2.38.1.tgz",
+      "integrity": "sha512-ecZ+YyzBK7r3tC8MTaGo5tySHPhB6f9jdxN706Tux6dMlcE2fgwiBM/bf/+Sz5m2yKlTq5ntiahz7xSPgurD6w=="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -13157,6 +13193,31 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
       }
     },
     "node_modules/proxy-addr": {
@@ -18009,6 +18070,35 @@
       "resolved": "https://registry.npmjs.org/@josephg/resolvable/-/resolvable-1.0.1.tgz",
       "integrity": "sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg=="
     },
+    "@kafkajs/confluent-schema-registry": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@kafkajs/confluent-schema-registry/-/confluent-schema-registry-3.2.1.tgz",
+      "integrity": "sha512-UERxB+w7Av39IpUjj0aCogbSrCGIMTFdZGtyoOskB/rF3tOi7k45VqZwRHsmedAVqhvSGAw+tJKevjLrCIgnkw==",
+      "requires": {
+        "ajv": "^7.1.0",
+        "avsc": ">= 5.4.13 < 6",
+        "mappersmith": ">= 2.30.1 < 3",
+        "protobufjs": "^6.10.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "7.2.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
+          "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
     "@nestjs-yalc/ag-grid": {
       "version": "file:ag-grid"
     },
@@ -19153,6 +19243,11 @@
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
+    "avsc": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.3.tgz",
+      "integrity": "sha512-uUbetCWczQHbsKyX1C99XpQHBM8SWfovvaZhPIj23/1uV7SQf0WeRZbiLpw0JZm+LHTChfNgrLfDJOVoU2kU+A=="
+    },
     "avvio": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/avvio/-/avvio-7.2.2.tgz",
@@ -20196,9 +20291,9 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decimal.js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-3.0.1.tgz",
-      "integrity": "sha1-Rgmlo0P4t69Cn6dupKTEQnxtBl4="
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -24947,12 +25042,6 @@
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
-        "decimal.js": {
-          "version": "10.3.1",
-          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-          "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
-          "dev": true
-        },
         "ws": {
           "version": "7.5.6",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
@@ -25366,6 +25455,11 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "mappersmith": {
+      "version": "2.38.1",
+      "resolved": "https://registry.npmjs.org/mappersmith/-/mappersmith-2.38.1.tgz",
+      "integrity": "sha512-ecZ+YyzBK7r3tC8MTaGo5tySHPhB6f9jdxN706Tux6dMlcE2fgwiBM/bf/+Sz5m2yKlTq5ntiahz7xSPgurD6w=="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -26459,6 +26553,26 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "protobufjs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
       }
     },
     "proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@apollo/federation": "^0.33.3",
     "@apollo/subgraph": "^0.1.2",
     "@graphql-tools/wrap": "^8.3.0",
+    "@kafkajs/confluent-schema-registry": "^3.2.1",
     "@nestjs/axios": "^0.0.3",
     "@nestjs/common": "^8.1.1",
     "@nestjs/config": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestjs-yalc/framework",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "NestJS - Yet Another Library Collection",
   "scripts": {
     "lint": "npm run lint:no-fix -- --fix",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,7 +40,9 @@
       "@nestjs-yalc/jest": ["jest/src"],
       "@nestjs-yalc/jest/*": ["jest/src/*"],
       "@nestjs-yalc/types": ["types/src"],
-      "@nestjs-yalc/types/*": ["types/src/*"]
+      "@nestjs-yalc/types/*": ["types/src/*"],
+      "@nestjs-yalc/kafka": ["kafka/src"],
+      "@nestjs-yalc/kafka/*": ["kafka/src/*"]
     }
   },
   "include": ["**/src/**/*.ts"],

--- a/types/src/modules.d.ts
+++ b/types/src/modules.d.ts
@@ -4,3 +4,5 @@ declare module 'google-libphonenumber';
 declare module 'decimal.js';
 declare module '@nestjs-yalc';
 declare module 'fastify-xml-body-parser';
+declare module 'kafkajs-snappy';
+declare module 'kafkajs';


### PR DESCRIPTION
## Added
- New kafka generic controller for nest microservices applications
- Avro deserializer
- Generic interface for debezium data
- New logic in extraArgs: possibility to add a fixed filter with runtime value assignment.

## Changed
- join field type is only JoinType

## Fixed
- DateType  graphql scalar
- Fixed filterConditions problem with some filter on Date type
- Fixed One-to-many relationship problem with nested resource as aggrid type
